### PR TITLE
Refresh portfolio website content and projects

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,20 +9,22 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v2
       with:
-        version: 8
-    - uses: actions/setup-node@v3
+        version: 10.13.1
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
         cache: 'pnpm'
     - name: Install dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
+    - name: Build website
+      run: pnpm build
     - name: Install Playwright Browsers
-      run: pnpm dlx playwright install --with-deps
+      run: pnpm exec playwright install --with-deps
     - name: Run Playwright tests
-      run: node node_modules/@playwright/test/cli.js test
+      run: pnpm exec playwright test
     - uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/components/Contact/component.tsx
+++ b/components/Contact/component.tsx
@@ -7,7 +7,7 @@ export const Contact: FC = () => {
       className="mt-20 mb-16 md:mt-28"
       title={"Wanna reach out?"}
       description={
-        "Feel free to drop me a message if you have some interesting offer or you want to hang out."
+        "I am open to conversations about senior engineering, AI, and full-stack opportunities."
       }
     >
       <Container>

--- a/components/Experience/component.tsx
+++ b/components/Experience/component.tsx
@@ -13,14 +13,19 @@ export const Experience: FC = () => {
 
   const experience = [
     {
+      title: "Senior Software Engineer",
+      place: "Criteria Corp",
+      date: "Feb 2025 - Present",
+    },
+    {
       title: "Senior Full Stack Web Developer",
       place: "RBC",
-      date: "Dec 2023 - Present",
+      date: "Dec 2023 - Feb 2025",
     },
     {
       title: "Full Stack Web Developer",
       place: "Neuravue",
-      date: "Mar 2022 - Present",
+      date: "Mar 2022 - Aug 2023",
     },
     {
       title: "Full Stack Web Developer",
@@ -73,7 +78,7 @@ export const Experience: FC = () => {
                     {...item}
                     key={i}
                     first={i === 0}
-                    last={i === 2}
+                    last={item.place === "SOTI Inc"}
                     controls={controls}
                     custom={i}
                   />

--- a/components/Experience/libs/Item/component.tsx
+++ b/components/Experience/libs/Item/component.tsx
@@ -30,7 +30,7 @@ export const Item: FC<Props> = ({
       animate={controls}
       custom={custom}
     >
-      {!last && (
+      {!last && place !== "SOTI Inc" && (
         <div
           className="absolute h-20 top-14 w-0.5 dark:bg-white-300 bg-white-700"
           style={{ left: "0.2rem" }}

--- a/components/Footer/component.tsx
+++ b/components/Footer/component.tsx
@@ -11,7 +11,7 @@ export const Footer: FC = () => {
           className="hover:opacity-80 transition-opacity"
           rel="noreferrer"
         >
-          Designed & Crafted by Tarun Singh © 2021
+          Designed & Crafted by Tarun Singh © 2026
         </a>
       </p>
     </Container>

--- a/components/Hero/component.tsx
+++ b/components/Hero/component.tsx
@@ -22,15 +22,17 @@ export const Hero: FC = () => {
           <HandWave className="text-4xl md:text-5xl wave" />
         </h1>
         <h1 className="text-2xl font-bold md:mt-8 md:mb-8 md:text-2xl text-black-900 dark:text-white-900 align-right">
-          {"@ Toronto, ON"}
+          {"@ India 🇮🇳"}
         </h1>
       </div>
       <p className="text-xl font-bold tracking-normal md:text-3xl text-black-700 dark:text-white-700">
-        {"Software Engineer"}{" "}
-        <HeroLink title={"RBC"} href="https://rbcroyalbank.com" /> {" & "}{" "}
-        <HeroLink title={"Neuravue"} href="https://neuravue.com" />
+        {"Senior Software Engineer"}{" "}
+        <HeroLink title={"Criteria Corp"} href="https://www.criteriacorp.com" />
         <br />
-        {"Previously Full Stack developer"}{" "}
+        {"Building production AI systems and full-stack products"}
+        <br />
+        {"Previously a Full Stack Developer at"}{" "}
+        <HeroLink title={"RBC"} href="https://rbcroyalbank.com" /> {", "}
         <HeroLink title={"SOTI"} href="https://soti.net" /> {", "}
         <HeroLink title={"Basebuild"} href="https://basebuild.com" /> {" & "}
         <HeroLink title="Kisan Network" href="https://kisannetwork.com" />{" "}
@@ -63,12 +65,12 @@ export const Hero: FC = () => {
       <div className="mt-10">
         <p className="mb-2 text-base md:text-xl dark:text-white-700 text-black-700">
           {
-            "I enjoy creating high-quality software products and projects with a complex logic behind it."
+            "I design and ship reliable software across AI, backend, and frontend systems."
           }
         </p>
         <p className="mb-2 text-base md:text-xl dark:text-white-700 text-black-700">
           {
-            "My technology stack includes NextJS, Angular, React, TypeScript, NodeJS, Express, Golang, MongoDB, PostgreSQL and python."
+            "My current stack includes TypeScript, React, Node.js, PHP/Laravel, AWS Bedrock, LangChain, MCP, MySQL, Redis, and Docker."
           }
         </p>
       </div>

--- a/components/Projects/component.tsx
+++ b/components/Projects/component.tsx
@@ -1,12 +1,125 @@
-import { Section } from "components";
+import { Container, Section } from "components";
+import { motion } from "framer-motion";
 import React, { FC } from "react";
+import { FaArrowUpRightFromSquare, FaGithub } from "react-icons/fa6";
+
+const supportingProjects = [
+  {
+    title: "Monitoring and Scraping API",
+    subtitle: "Personal monitoring and scraping service",
+    description:
+      "A backend service for monitoring websites and running scheduled scraping jobs with a focus on dependable, repeatable automation.",
+    technologies: "Node.js · TypeScript · REST API",
+    href: "https://github.com/tarun7singh/website-api",
+    icon: <FaGithub aria-hidden="true" />,
+  },
+  {
+    title: "Visa Appointment Checker",
+    subtitle: "Appointment availability tracker",
+    description:
+      "An automation tool that checks appointment availability and helps reduce the manual effort involved in finding an open slot.",
+    technologies: "JavaScript · Automation",
+    href: "https://github.com/tarun7singh/visa-appointment-checker",
+    icon: <FaGithub aria-hidden="true" />,
+  },
+];
+
+const cardClassName =
+  "group rounded-xl border border-gray-700 bg-white p-6 transition-all duration-200 hover:-translate-y-1 hover:border-blue-900 dark:border-white-300 dark:bg-gray-900";
 
 export const Projects: FC = () => {
   return (
     <Section
       className="md:mt-20 mt-14"
       title={"Projects"}
-      description={"This section is under development."}
-    ></Section>
+      description={"Selected products and experiments I have built or helped ship."}
+    >
+      <Container className="mt-8">
+        <div className="grid gap-5 md:grid-cols-2">
+          <motion.div
+            className="relative overflow-hidden rounded-xl border border-blue-900 bg-blue-900 p-6 text-white-900 md:col-span-2 md:p-8"
+            whileHover={{ y: -4 }}
+            transition={{ duration: 0.2 }}
+          >
+            <div className="absolute -right-16 -top-20 h-48 w-48 rounded-full border border-white-900 opacity-10" />
+            <div className="absolute -bottom-24 right-20 h-56 w-56 rounded-full border border-white-900 opacity-10" />
+            <div className="relative grid gap-8 md:grid-cols-[1fr_auto] md:items-end">
+              <div>
+                <p className="mb-5 text-sm font-medium uppercase tracking-[0.2em] text-white-700">
+                  Featured project · 01
+                </p>
+                <h3 className="text-3xl font-bold md:text-4xl">Coach Bo</h3>
+                <p className="mt-2 text-lg font-medium text-white-700">
+                  Production agentic AI coaching assistant
+                </p>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-white-700 md:text-lg">
+                  A multi-turn AI system combining AWS Bedrock, LangChain, and
+                  MCP tools to deliver grounded coaching conversations with
+                  identity and hallucination safeguards.
+                </p>
+              </div>
+              <div className="md:min-w-52">
+                <p className="mb-3 text-sm font-medium uppercase tracking-[0.15em] text-white-500">
+                  Built with
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {["AWS Bedrock", "LangChain", "MCP", "TypeScript"].map(
+                    (technology) => (
+                      <span
+                        key={technology}
+                        className="rounded-full border border-white-700 px-3 py-1 text-sm text-white-700"
+                      >
+                        {technology}
+                      </span>
+                    )
+                  )}
+                </div>
+                <a
+                  href="https://www.criteriacorp.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-white-900 underline decoration-white-500 underline-offset-4 transition-opacity hover:opacity-70"
+                >
+                  About Criteria Corp <FaArrowUpRightFromSquare aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+          </motion.div>
+
+          {supportingProjects.map((project, index) => (
+            <motion.a
+              key={project.title}
+              href={project.href}
+              target="_blank"
+              rel="noreferrer"
+              className={cardClassName}
+              whileHover={{ y: -4 }}
+              transition={{ duration: 0.2 }}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <p className="text-sm font-medium uppercase tracking-[0.15em] text-black-700 dark:text-white-500">
+                  {`0${index + 2}`} / Personal project
+                </p>
+                <span className="text-black-700 transition-transform group-hover:translate-x-1 group-hover:-translate-y-1 dark:text-white-700">
+                  {project.icon}
+                </span>
+              </div>
+              <h3 className="mt-8 text-xl font-bold text-black-900 dark:text-white-900">
+                {project.title}
+              </h3>
+              <p className="mt-2 text-base font-medium text-black-700 dark:text-white-700">
+                {project.subtitle}
+              </p>
+              <p className="mt-4 text-base leading-7 text-black-700 dark:text-white-700">
+                {project.description}
+              </p>
+              <p className="mt-6 text-sm font-medium text-black-700 dark:text-white-500">
+                {project.technologies}
+              </p>
+            </motion.a>
+          ))}
+        </div>
+      </Container>
+    </Section>
   );
 };

--- a/components/Skills/component.tsx
+++ b/components/Skills/component.tsx
@@ -3,15 +3,18 @@
 import { Container, Section } from "components";
 import { useAnimation } from "framer-motion";
 import React, { FC, useEffect } from "react";
-import { FaReact } from "react-icons/fa";
+import { FaAws, FaDocker, FaPhp, FaReact } from "react-icons/fa";
+import {
+  SiLangchain,
+  SiReactquery,
+  SiRedis,
+  SiVite,
+} from "react-icons/si";
 import { useInView } from "react-intersection-observer";
 
 import {
-  ActionsIcon,
-  GCloudIcon,
-  GoIcon,
-  MongoDBIcon,
   MySQLIcon,
+  McpIcon,
   NodeJSIcon,
   TsIcon,
 } from "./libs/Icons";
@@ -25,15 +28,33 @@ const skills = [
     main: true,
   },
   {
+    name: "React",
+    href: "https://react.dev",
+    icon: <FaReact color="#00D8FF" />,
+    main: true,
+  },
+  {
     name: "Node.js",
     href: "https://nodejs.org",
     icon: <NodeJSIcon />,
     main: true,
   },
   {
-    name: "React",
-    href: "https://reactjs.org",
-    icon: <FaReact color="#00D8FF" />,
+    name: "AWS Bedrock",
+    href: "https://aws.amazon.com/bedrock/",
+    icon: <FaAws color="#FF9900" />,
+    main: true,
+  },
+  {
+    name: "PHP / Laravel",
+    href: "https://laravel.com",
+    icon: <FaPhp color="#777BB4" />,
+    main: true,
+  },
+  {
+    name: "MCP / Agentic AI",
+    href: "https://modelcontextprotocol.io",
+    icon: <McpIcon />,
     main: true,
   },
   {
@@ -43,27 +64,33 @@ const skills = [
     main: true,
   },
   {
-    name: "MongoDB",
-    href: "https://www.mongodb.com",
-    icon: <MongoDBIcon />,
+    name: "Docker",
+    href: "https://www.docker.com",
+    icon: <FaDocker color="#2496ED" />,
     main: true,
   },
   {
-    name: "Google Cloud",
-    href: "https://cloud.google.com",
-    icon: <GCloudIcon />,
+    name: "LangChain",
+    href: "https://www.langchain.com",
+    icon: <SiLangchain color="#1C3C3C" />,
     main: true,
   },
   {
-    name: "Github Actions",
-    href: "https://github.com/features/actions",
-    icon: <ActionsIcon />,
-    main: false,
+    name: "TanStack Query",
+    href: "https://tanstack.com/query",
+    icon: <SiReactquery color="#FF4154" />,
+    main: true,
   },
   {
-    name: "Golang",
-    href: "https://golang.org",
-    icon: <GoIcon />,
+    name: "Redis",
+    href: "https://redis.io",
+    icon: <SiRedis color="#DC382D" />,
+    main: true,
+  },
+  {
+    name: "Vite",
+    href: "https://vite.dev",
+    icon: <SiVite color="#646CFF" />,
     main: true,
   },
 ];

--- a/components/Skills/libs/Icons/component.tsx
+++ b/components/Skills/libs/Icons/component.tsx
@@ -418,3 +418,34 @@ export const GoIcon: FC<Props> = ({ className }: Props) => {
     </svg>
   );
 };
+
+export const McpIcon: FC<Props> = ({ className }: Props) => {
+  return (
+    <svg
+      viewBox="0 0 195 195"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-label="Model Context Protocol"
+    >
+      <path
+        d="M25 97.8528L92.8823 29.9706C102.255 20.598 117.451 20.598 126.823 29.9706C136.196 39.3431 136.196 54.5391 126.823 63.9117L75.5581 115.177"
+        stroke="currentColor"
+        strokeWidth="12"
+        strokeLinecap="round"
+      />
+      <path
+        d="M76.2653 114.47L126.823 63.9117C136.196 54.5391 151.392 54.5391 160.765 63.9117L161.118 64.2652C170.491 73.6378 170.491 88.8338 161.118 98.2063L99.7248 159.6C96.6006 162.724 96.6006 167.789 99.7248 170.913L112.331 183.52"
+        stroke="currentColor"
+        strokeWidth="12"
+        strokeLinecap="round"
+      />
+      <path
+        d="M109.853 46.9411L59.6482 97.1457C50.2757 106.518 50.2757 121.714 59.6482 131.087C69.0208 140.459 84.2168 140.459 93.5894 131.087L143.794 80.8822"
+        stroke="currentColor"
+        strokeWidth="12"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};

--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,20 +1,56 @@
+const siteUrl = "https://tarunsingh.dev";
+
 export default {
   title: "Tarun Singh | Senior Software Engineer | AI and Full Stack",
-  description: "Tarun Singh is a Senior Software Engineer in Toronto building production AI systems and full-stack products with TypeScript, React, Node.js, Laravel, and AWS Bedrock.",
-  canonical: "https://www.tarunsingh.dev",
+  description:
+    "Tarun Singh is a Senior Software Engineer building production AI systems and full-stack products with TypeScript, React, Node.js, Laravel, and AWS Bedrock.",
+  canonical: siteUrl,
+  additionalMetaTags: [
+    {
+      name: "author",
+      content: "Tarun Singh",
+    },
+    {
+      name: "robots",
+      content:
+        "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1",
+    },
+    {
+      name: "googlebot",
+      content:
+        "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1",
+    },
+  ],
+  additionalLinkTags: [
+    {
+      rel: "me",
+      href: "https://www.linkedin.com/in/tarun7singh/",
+    },
+    {
+      rel: "me",
+      href: "https://github.com/tarun7singh",
+    },
+  ],
   openGraph: {
     type: "website",
-    url: "https://tarusingh.dev",
+    url: siteUrl,
     title: "Tarun Singh | Senior Software Engineer",
-    description: "Production AI systems and full-stack products built with TypeScript, React, Node.js, Laravel, and AWS Bedrock.",
+    description:
+      "Production AI systems and full-stack products built with TypeScript, React, Node.js, Laravel, and AWS Bedrock.",
+    locale: "en",
     images: [
       {
-        url: "https://tarunsingh.dev/og.png",
+        url: `${siteUrl}/og.png`,
         width: 800,
         height: 600,
-        alt: "Og Image Alt",
+        alt: "Tarun Singh, Senior Software Engineer",
       },
     ],
-    site_name: "Portfolio | Tarun Singh",
+    site_name: "Tarun Singh",
+  },
+  twitter: {
+    handle: "@tarun7singh",
+    site: "@tarun7singh",
+    cardType: "summary_large_image",
   },
 };

--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,12 +1,12 @@
 export default {
-  title: "Tarun Singh | Full Stack Developer | Typescript, NodeJS, ReactJS",
-  description: "Tarun Singh | Full Stack developer at Toronto, ON, Canada and Freelancer | Skills : Javascript, Typescript, NodeJS, ReactJS, MySQL, MongoDB, Golang",
+  title: "Tarun Singh | Senior Software Engineer | AI and Full Stack",
+  description: "Tarun Singh is a Senior Software Engineer in Toronto building production AI systems and full-stack products with TypeScript, React, Node.js, Laravel, and AWS Bedrock.",
   canonical: "https://www.tarunsingh.dev",
   openGraph: {
     type: "website",
     url: "https://tarusingh.dev",
-    title: "Portfolio | Tarun Singh",
-    description: "Full Stack web developer @ Toronto",
+    title: "Tarun Singh | Senior Software Engineer",
+    description: "Production AI systems and full-stack products built with TypeScript, React, Node.js, Laravel, and AWS Bedrock.",
     images: [
       {
         url: "https://tarunsingh.dev/og.png",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,6 +12,8 @@ import { motion } from "framer-motion";
 import Head from "next/head";
 import React, { useEffect, useState } from "react";
 
+const siteUrl = "https://tarunsingh.dev";
+
 const IndexPage = () => {
   const [main, setMain] = useState(false);
 
@@ -28,8 +30,77 @@ const IndexPage = () => {
           {"Tarun Singh | Senior Software Engineer | AI and Full Stack"}
         </title>
         <meta
-          name="keywords"
-          content="Tarun Singh, Senior Software Engineer, AI Engineer, Full Stack Engineer, AWS Bedrock, LangChain, MCP, TypeScript, React, Node.js, Laravel, Toronto"
+          name="description"
+          content="Tarun Singh is a Senior Software Engineer building production AI systems and full-stack products with TypeScript, React, Node.js, Laravel, and AWS Bedrock."
+        />
+        <link rel="canonical" href={siteUrl} />
+        <meta name="author" content="Tarun Singh" />
+        <meta name="robots" content="index,follow" />
+        <meta property="og:type" content="website" />
+        <meta property="og:locale" content="en" />
+        <meta property="og:url" content={siteUrl} />
+        <meta property="og:site_name" content="Tarun Singh" />
+        <meta
+          property="og:title"
+          content="Tarun Singh | Senior Software Engineer"
+        />
+        <meta
+          property="og:description"
+          content="Production AI systems and full-stack products built with TypeScript, React, Node.js, Laravel, and AWS Bedrock."
+        />
+        <meta property="og:image" content={`${siteUrl}/og.png`} />
+        <meta
+          property="og:image:alt"
+          content="Tarun Singh, Senior Software Engineer"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@tarun7singh" />
+        <meta name="twitter:creator" content="@tarun7singh" />
+        <meta
+          name="twitter:title"
+          content="Tarun Singh | Senior Software Engineer"
+        />
+        <meta
+          name="twitter:description"
+          content="Production AI systems and full-stack products built with TypeScript, React, Node.js, Laravel, and AWS Bedrock."
+        />
+        <meta name="twitter:image" content={`${siteUrl}/og.png`} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "ProfilePage",
+              name: "Tarun Singh | Senior Software Engineer",
+              url: siteUrl,
+              mainEntity: {
+                "@type": "Person",
+                name: "Tarun Singh",
+                url: siteUrl,
+                image: `${siteUrl}/images/me.webp`,
+                jobTitle: "Senior Software Engineer",
+                description:
+                  "Senior Software Engineer building production AI systems and full-stack products.",
+                sameAs: [
+                  "https://github.com/tarun7singh",
+                  "https://www.linkedin.com/in/tarun7singh/",
+                  "https://twitter.com/tarun7singh",
+                ],
+                knowsAbout: [
+                  "Artificial intelligence",
+                  "Agentic AI",
+                  "AWS Bedrock",
+                  "LangChain",
+                  "Model Context Protocol",
+                  "TypeScript",
+                  "React",
+                  "Node.js",
+                  "PHP",
+                  "Laravel",
+                ],
+              },
+            }),
+          }}
         />
       </Head>
       <motion.div

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,11 +25,11 @@ const IndexPage = () => {
     <>
       <Head>
         <title>
-          {"Tarun Singh | Full Stack Developer | Typescript, NodeJS, ReactJS"}
+          {"Tarun Singh | Senior Software Engineer | AI and Full Stack"}
         </title>
         <meta
           name="keywords"
-          content="Tarun, Singh, Web developer, Full Stack web developer, Portfolio, Javascript, Typescript, NodeJS, ReactJS, MySQL, MongoDB, Golang, freelancer, toronto"
+          content="Tarun Singh, Senior Software Engineer, AI Engineer, Full Stack Engineer, AWS Bedrock, LangChain, MCP, TypeScript, React, Node.js, Laravel, Toronto"
         />
       </Head>
       <motion.div

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: "http://127.0.0.1:3000",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -69,9 +69,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: "pnpm start",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /api/
 
 Sitemap: https://tarunsingh.dev/sitemap.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,19 +1,24 @@
 {
-    "name": "",
-    "short_name": "",
-    "icons": [
-        {
-            "src": "/android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/android-chrome-256x256.png",
-            "sizes": "256x256",
-            "type": "image/png"
-        }
-    ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
-    "display": "standalone"
+  "name": "Tarun Singh | Senior Software Engineer",
+  "short_name": "Tarun Singh",
+  "description": "Portfolio of Tarun Singh, a Senior Software Engineer building production AI systems and full-stack products.",
+  "start_url": "/",
+  "scope": "/",
+  "lang": "en",
+  "dir": "ltr",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-256x256.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#171a23",
+  "background_color": "#171a23",
+  "display": "standalone"
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,27 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset
-      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
-
-
-<url>
-  <loc>https://tarunsingh.dev/</loc>
-  <lastmod>2021-09-02T10:41:24+00:00</lastmod>
-  <priority>1.00</priority>
-</url>
-<url>
-  <loc>https://blog.tarunsingh.dev/</loc>
-  <lastmod>2024-12-08T10:41:24+00:00</lastmod>
-  <priority>0.75</priority>
-</url>
-<url>
-  <loc>https://tarunsingh.dev/Resume.pdf</loc>
-  <lastmod>2021-09-02T10:41:24+00:00</lastmod>
-  <priority>0.50</priority>
-</url>
-
-
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://tarunsingh.dev/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://tarunsingh.dev/resume/Resume.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
 
 test("has title", async ({ page }) => {
-  await page.goto("https://tarunsingh.dev/");
+  await page.goto("/");
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(
-    /Tarun Singh | Full Stack Developer | Typescript, NodeJS, ReactJS/
+    /Tarun Singh | Senior Software Engineer | AI and Full Stack/
   );
 });
 
@@ -17,7 +17,7 @@ test("validate all links", async ({ page }) => {
     resume: "https://tarunsingh.dev/resume/Resume.pdf",
     email: "mailto:hello@tarunsingh.dev",
   };
-  await page.goto("https://tarunsingh.dev/");
+  await page.goto("/");
   expect(
     await page
       .getByRole("link", { name: "LinkedIn Profile" })


### PR DESCRIPTION
## Summary
- Update personal branding, current role, location, and experience dates
- Refresh the technology banner with current AI/full-stack tools and official logos
- Add a featured Coach Bo project and supporting personal project cards
- Improve SEO with consistent canonical URLs, robots directives, sitemap cleanup, Open Graph/Twitter metadata, JSON-LD ProfilePage/Person structured data, identity links, and branded web manifest
- Improve contact copy and footer year
- Fix the experience timeline connector after SOTI

## Verification
- `pnpm build`
- `pnpm exec playwright test` (6 passed across Chromium, Firefox, and WebKit; tests currently target the deployed site)