### PR TITLE
fix: clean up portfolio SEO metadata

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.tarunsingh.dev
+tarunsingh.dev

--- a/components/Header/component.tsx
+++ b/components/Header/component.tsx
@@ -44,12 +44,12 @@ export const Header: FC = () => {
     >
       <Container className="flex items-center justify-between w-auto py-2 md:py-4 text-black-900 dark:text-white-900">
         <Link href="/" passHref>
-          <h1
+          <span
             style={{ fontFamily: "tangerine" }}
             className="text-4xl font-bold md:mt-8 md:mb-8 md:text-5xl text-black-900 dark:text-white-900"
           >
             Tarun Singh
-          </h1>
+          </span>
         </Link>
         <div className="flex items-center">
           <button

--- a/components/Hero/component.tsx
+++ b/components/Hero/component.tsx
@@ -13,7 +13,7 @@ export const Hero: FC = () => {
         src="/images/me.webp"
         width="160"
         height="160"
-        alt="me"
+        alt="Tarun Singh, Senior Software Engineer"
         className="w-40 h-40 border border-gray-700 rounded-full mt-28 md:w-34 md:h-34"
       />
       <div className="flex">
@@ -21,9 +21,9 @@ export const Hero: FC = () => {
           {"Hi, I'm Tarun!"}
           <HandWave className="text-4xl md:text-5xl wave" />
         </h1>
-        <h1 className="text-2xl font-bold md:mt-8 md:mb-8 md:text-2xl text-black-900 dark:text-white-900 align-right">
+        <span className="text-2xl font-bold md:mt-8 md:mb-8 md:text-2xl text-black-900 dark:text-white-900 align-right">
           {"@ India 🇮🇳"}
-        </h1>
+        </span>
       </div>
       <p className="text-xl font-bold tracking-normal md:text-3xl text-black-700 dark:text-white-700">
         {"Senior Software Engineer"}{" "}
@@ -58,7 +58,7 @@ export const Hero: FC = () => {
         />
         <MediaIcon
           icon={<FaFilePdf className="w-6 h-6 md:w-7 md:h-7" />}
-          href="https://tarunsingh.dev/resume/Resume.pdf"
+          href="/Resume.pdf"
           ariaLabel="Resume-PDF"
         />
       </div>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,12 +3,9 @@ import "styles/index.css";
 import { Layout } from "components";
 import { AppProps } from "next/app";
 import Head from "next/head";
-import { generateDefaultSeo } from "next-seo/pages";
 import { ThemeProvider } from "next-themes";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-
-import SEO from "../next-seo.config";
 
 if (typeof window !== "undefined") {
   // checks that we are client-side
@@ -30,7 +27,6 @@ export default function App({
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
       <Head>
-        {generateDefaultSeo(SEO)}
         <link
           rel="apple-touch-icon"
           sizes="180x180"

--- a/pages/flag-guard/privacy.tsx
+++ b/pages/flag-guard/privacy.tsx
@@ -1,15 +1,28 @@
 import { Container, Layout } from "components";
 import Head from "next/head";
 
+const siteUrl = "https://tarunsingh.dev";
+const pageUrl = `${siteUrl}/flag-guard/privacy/`;
+const pageTitle = "Privacy Policy | Tarun Singh";
+const pageDescription =
+  "Privacy Policy for Flag Guard - VPN & IP Location Verifier browser extension developed by Tarun Singh";
+
 const PrivacyPage = () => {
   return (
     <>
       <Head>
-        <title>Privacy Policy | Tarun Singh</title>
-        <meta
-          name="description"
-          content="Privacy Policy for Flag Guard - VPN & IP Location Verifier browser extension developed by Tarun Singh"
-        />
+        <title>{pageTitle}</title>
+        <meta name="description" content={pageDescription} />
+        <link rel="canonical" href={pageUrl} />
+        <meta name="robots" content="index,follow" />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={pageUrl} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDescription} />
+        <meta property="og:site_name" content="Tarun Singh" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={pageDescription} />
       </Head>
       <Layout>
         <Container>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,8 +6,13 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://tarunsingh.dev/resume/Resume.pdf</loc>
+    <loc>https://tarunsingh.dev/Resume.pdf</loc>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://tarunsingh.dev/flag-guard/privacy/</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -14,7 +14,7 @@ test("validate all links", async ({ page }) => {
     linkedIn: "https://www.linkedin.com/in/tarun7singh/",
     github: "https://github.com/tarun7singh",
     twitter: "https://twitter.com/tarun7singh",
-    resume: "https://tarunsingh.dev/resume/Resume.pdf",
+    resume: "/Resume.pdf",
     email: "mailto:hello@tarunsingh.dev",
   };
   await page.goto("/");
@@ -41,4 +41,29 @@ test("validate all links", async ({ page }) => {
       .getByRole("link", { name: "hello@tarunsingh.dev" })
       .getAttribute("href")
   ).toEqual(validLinks.email);
+});
+
+test("has one canonical homepage heading and no duplicate SEO tags", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await expect(page.locator("h1")).toHaveCount(1);
+  await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="description"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="robots"]')).toHaveCount(1);
+});
+
+test("privacy page has page-specific SEO metadata", async ({ page }) => {
+  await page.goto("/flag-guard/privacy/");
+
+  await expect(page).toHaveTitle("Privacy Policy | Tarun Singh");
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    "https://tarunsingh.dev/flag-guard/privacy/"
+  );
+  await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+    "content",
+    "Privacy Policy | Tarun Singh"
+  );
 });


### PR DESCRIPTION
## Summary
- align the canonical domain and fix resume/sitemap URLs
- remove duplicated homepage SEO metadata and enforce one heading
- add page-specific privacy-page metadata
- add SEO regression coverage

## Validation
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (12 passed)

## Follow-up
- resubmit the sitemap and affected URLs in Google Search Console after deployment
- investigate the remaining indexing exclusions